### PR TITLE
Undefined name: profile[conf_username] --> profile['conf_username']

### DIFF
--- a/jiveToConfluence.py
+++ b/jiveToConfluence.py
@@ -33,7 +33,7 @@ def purgeConfluence():
 	sure = raw_input("Do you want to delete all existing Questions, in all spaces, in Confluence first?!  (y/n)")
 	if sure == "y":
 		print "Destroying ALLLLLL questions in confluence"
-		url = profile[conf_baseUrl] + "/rest/questions/1.0/search?limit=500&type=question"
+		url = profile['conf_baseUrl'] + "/rest/questions/1.0/search?limit=500&type=question"
 		r = requests.get(url,verify=False,auth=(profile['conf_username'], profile['conf_password']))
 		print "Result:" + str(r.status_code)
 		questions = json.loads(r.text)
@@ -45,7 +45,7 @@ def purgeConfluence():
 				for thread in threads:
 					if not thread.isAlive():
 						threads.remove(thread)
-			thr = threading.Thread(target=deleteQuestion, args=([profile[conf_baseUrl] + "/rest/questions/1.0/question/" + str(question['id'])]))
+			thr = threading.Thread(target=deleteQuestion, args=([profile['conf_baseUrl'] + "/rest/questions/1.0/question/" + str(question['id'])]))
 			thr.start() # will run "foo"
 			threads.append(thr)
 		for thread in threads:


### PR DESCRIPTION
__conf_username__ is an _undefined name_ in this context but __profile['conf_username']__ matches with other uses in this repo.

flake8 testing of https://github.com/eddiewebb/jive-confluence-migrator on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./jiveToConfluence.py:36:17: F821 undefined name 'conf_baseUrl'
		url = profile[conf_baseUrl] + "/rest/questions/1.0/search?limit=500&type=question"
                ^
./jiveToConfluence.py:48:65: F821 undefined name 'conf_baseUrl'
			thr = threading.Thread(target=deleteQuestion, args=([profile[conf_baseUrl] + "/rest/questions/1.0/question/" + str(question['id'])]))
                                                                ^
2     F821 undefined name 'conf_baseUrl'
2
```